### PR TITLE
Fixed invalid graph description for network monitoring

### DIFF
--- a/ansible/roles/esdc-mon/files/templates/t_erigonos.json
+++ b/ansible/roles/esdc-mon/files/templates/t_erigonos.json
@@ -1661,7 +1661,7 @@
                                 "password": "",
                                 "snmpv3_privpassphrase": "",
                                 "snmpv3_privprotocol": "0",
-                                "name": "Incoming errors on $1",
+                                "name": "Incoming errors on {#IFNAME}",
                                 "applications": [
                                     {
                                         "name": "Network interfaces"
@@ -1704,7 +1704,7 @@
                                 "password": "",
                                 "snmpv3_privpassphrase": "",
                                 "snmpv3_privprotocol": "0",
-                                "name": "Incoming network traffic on $1",
+                                "name": "Incoming network traffic on {#IFNAME}",
                                 "applications": [
                                     {
                                         "name": "Network interfaces"
@@ -1747,7 +1747,7 @@
                                 "password": "",
                                 "snmpv3_privpassphrase": "",
                                 "snmpv3_privprotocol": "0",
-                                "name": "Incoming packets on $1",
+                                "name": "Incoming packets on {#IFNAME}",
                                 "applications": [
                                     {
                                         "name": "Network interfaces"
@@ -1790,7 +1790,7 @@
                                 "password": "",
                                 "snmpv3_privpassphrase": "",
                                 "snmpv3_privprotocol": "0",
-                                "name": "Outgoing errors on $1",
+                                "name": "Outgoing errors on {#IFNAME}",
                                 "applications": [
                                     {
                                         "name": "Network interfaces"
@@ -1833,7 +1833,7 @@
                                 "password": "",
                                 "snmpv3_privpassphrase": "",
                                 "snmpv3_privprotocol": "0",
-                                "name": "Outgoing network traffic on $1",
+                                "name": "Outgoing network traffic on {#IFNAME}",
                                 "applications": [
                                     {
                                         "name": "Network interfaces"
@@ -1876,7 +1876,7 @@
                                 "password": "",
                                 "snmpv3_privpassphrase": "",
                                 "snmpv3_privprotocol": "0",
-                                "name": "Outgoing packets on $1",
+                                "name": "Outgoing packets on {#IFNAME}",
                                 "applications": [
                                     {
                                         "name": "Network interfaces"

--- a/docs/appliances.rst
+++ b/docs/appliances.rst
@@ -338,6 +338,7 @@ Changelog
 - Fixed exec parameters of default media types - `#29 <https://github.com/erigones/esdc-factory/issues/29>`__
 - Fixed FS discovery in t_linux and t_erigonos templates - `#30 <https://github.com/erigones/esdc-factory/issues/30>`__
 - Fixed node hard disk discovery and added trigger on SCSI errors into t_solaris_disk - commit `273ad34 <https://github.com/erigones/esdc-factory/commit/273ad34e0c24ab7cb5f2de2f4478534bfa13230e>`__
+- Fixed invalid graph description for network monitoring in t_erigonos - `#34 <https://github.com/erigones/esdc-factory/issues/34>`__ - `#112 <https://github.com/erigones/esdc-ce/issues/112>`__
 
 2.5.1
 ~~~~~


### PR DESCRIPTION
Network monitoring graphs were showing $1 instead of
interface name.
Issue erigones/esdc-ce#112