### PR TITLE
Changed default PowerDNS server settings to be preconfigured as a master name server

### DIFF
--- a/ansible/roles/pdns/defaults/main.yml
+++ b/ansible/roles/pdns/defaults/main.yml
@@ -16,6 +16,8 @@ pdns_local_port: 53
 
 pdns_loglevel: 4
 
+pdns_master: "no"
+
 pdns_max_cache_entries: 1000000
 pdns_max_queue_length: 5000
 pdns_max_tcp_connections: 10

--- a/ansible/roles/pdns/templates/pdns.conf.j2
+++ b/ansible/roles/pdns/templates/pdns.conf.j2
@@ -169,7 +169,7 @@ loglevel={{ pdns_loglevel }}
 #################################
 # master    Act as a master
 #
-# master=no
+master={{ pdns_master }}
 
 #################################
 # max-cache-entries Maximum number of cache entries

--- a/ansible/vars/build/os/esdc-dns.yml
+++ b/ansible/vars/build/os/esdc-dns.yml
@@ -1,3 +1,7 @@
+pdns_allow_axfr_ips: ""
+pdns_disable_axfr: "no"
+pdns_master: "yes"
+
 pdns_db_host: "@PGSQL_HOST@"
 pdns_db_port: "@PGSQL_PORT@"
 pdns_db_user: "@PGSQL_USER@"

--- a/docs/appliances.rst
+++ b/docs/appliances.rst
@@ -146,6 +146,11 @@ The image supports following metadata (in addition to `base-64-es`_ image metada
 Changelog
 ---------
 
+2.6.0
+~~~~~
+
+- Changed default PowerDNS server settings to be preconfigured as a master name server - `#41 <https://github.com/erigones/esdc-factory/issues/41>`__
+
 2.5.2
 ~~~~~
 


### PR DESCRIPTION
Related to erigones/esdc-ce#118 and erigones/esdc-ce#151

New settings:

- allow-axfr-ips=
- disable-axfr=no
- master=yes