### PR TITLE
Changed database backend to be able to use transaction hooks

### DIFF
--- a/ansible/roles/esdc-mgmt/templates/esdc/local_settings.py.j2
+++ b/ansible/roles/esdc-mgmt/templates/esdc/local_settings.py.j2
@@ -2,7 +2,7 @@ SECRET_KEY = """{{ secret_key.stdout }}"""
 
 DATABASES = {
     'esdc': {
-        'ENGINE': 'django.db.backends.postgresql_psycopg2',
+        'ENGINE': 'transaction_hooks.backends.postgresql_psycopg2',
         'NAME': '{{ pgsql_esdc.name }}',
         'USER': '{{ pgsql_esdc.user }}',
         'PASSWORD': '{{ pgsql_esdc.password }}',
@@ -10,7 +10,7 @@ DATABASES = {
         'PORT': '{{ pgsql_esdc.port }}',
     },
     'pdns': {
-        'ENGINE': 'django.db.backends.postgresql_psycopg2',
+        'ENGINE': 'transaction_hooks.backends.postgresql_psycopg2',
         'NAME': '{{ pgsql_pdns.name }}',
         'USER': '{{ pgsql_esdc.user }}',
         'PASSWORD': '{{ pgsql_esdc.password }}',


### PR DESCRIPTION
A separate database backend, comming from django-transaction-hooks is needed before Django 1.9. By using django-transaction-hooks we are able to call celery tasks after db transaction is finished and therefore we eliminate the race condition, when we are trying to get information from the task but it's not in the database yet.

Depends on https://github.com/erigones/esdc-ce/pull/178