### PR TITLE
Updated esdc-dns appliance and first compute node installer to configure recursion forwarders

### DIFF
--- a/ansible/roles/esdc-dns/files/41-dns.sh
+++ b/ansible/roles/esdc-dns/files/41-dns.sh
@@ -13,7 +13,7 @@ declare -A PDNS_MDATA=(
 )
 
 declare -A PDNS_RECURSOR_MDATA=(
-	[recursor_forwarders]="forward-zones-recurse=."
+	[recursor_forwarders]="forward-zones-recurse"
 )
 
 update_config() {

--- a/ansible/roles/esdc-dns/files/41-dns.sh
+++ b/ansible/roles/esdc-dns/files/41-dns.sh
@@ -1,9 +1,10 @@
 #!/bin/bash
 
 MDATA_PREFIX="org.erigones"
-CONFIG_FILE="/opt/local/etc/pdns.conf"
+PDNS_CONFIG="/opt/local/etc/pdns.conf"
+PDNS_RECURSOR_CONFIG="/opt/local/etc/recursor.conf"
 
-declare -A MDATA_VARS=(
+declare -A PDNS_MDATA=(
 	[pgsql_host]="gpgsql-host"
 	[pgsql_port]="gpgsql-port"
 	[pgsql_user]="gpgsql-user"
@@ -11,24 +12,40 @@ declare -A MDATA_VARS=(
 	[pgsql_dbname]="gpgsql-dbname"
 )
 
-log "reading metadata and configuring ${CONFIG_FILE}"
+declare -A PDNS_RECURSOR_MDATA=(
+	[recursor_forwarders]="forward-zones-recurse=."
+)
 
-for key in "${!MDATA_VARS[@]}"; do
-	config_var="${MDATA_VARS[$key]}"
-	mdata_key="${MDATA_PREFIX}:${key}"
+update_config() {
+	local mdata_key="${1}"
+	local config_var="${2}"
+	local config_file="${3}"
+	local mdata_value
+
 	log "reading metadata key: \"${mdata_key}\""
 	mdata_value=$(mdata-get "${mdata_key}" 2>/dev/null)
 
+	# shellcheck disable=SC2181
 	if [[ $? -eq 0 ]]; then
 		log "found metadata key: \"${mdata_key}\" value: \"${mdata_value}\""
-		if gsed -i "/^${config_var}=/s/${config_var}.*/${config_var}=${mdata_value}/" "${CONFIG_FILE}"; then
-			log "set ${config_var}=${mdata_value} in ${CONFIG_FILE}"
+		if gsed -i "/^${config_var}=/s/${config_var}.*/${config_var}=${mdata_value}/" "${config_file}"; then
+			log "set ${config_var}=${mdata_value} in ${config_file}"
 		else
-			log "failed to set ${config_var}=${mdata_value} in ${CONFIG_FILE}"
+			log "failed to set ${config_var}=${mdata_value} in ${config_file}"
 		fi
 	else
-		log "missing metadata key: \"${mdata_key}\" (ignoring ${config_var} in ${CONFIG_FILE})"
+		log "missing metadata key: \"${mdata_key}\" (ignoring ${config_var} in ${config_file})"
 	fi
+}
+
+log "reading pdns metadata and configuring ${PDNS_CONFIG}"
+for key in "${!PDNS_MDATA[@]}"; do
+	update_config "${MDATA_PREFIX}:${key}" "${PDNS_MDATA[$key]}" "${PDNS_CONFIG}"
+done
+
+log "reading pdns metadata and configuring ${PDNS_RECURSOR_CONFIG}"
+for key in "${!PDNS_RECURSOR_MDATA[@]}"; do
+	update_config "${MDATA_PREFIX}:${key}" "${PDNS_RECURSOR_MDATA[$key]}" "${PDNS_RECURSOR_CONFIG}"
 done
 
 log "starting PowerDNS and PowerDNS recursor"

--- a/ansible/roles/esdc-dns/files/41-dns.sh
+++ b/ansible/roles/esdc-dns/files/41-dns.sh
@@ -21,6 +21,7 @@ update_config() {
 	local config_var="${2}"
 	local config_file="${3}"
 	local mdata_value
+	local config_value
 
 	log "reading metadata key: \"${mdata_key}\""
 	mdata_value=$(mdata-get "${mdata_key}" 2>/dev/null)
@@ -28,7 +29,13 @@ update_config() {
 	# shellcheck disable=SC2181
 	if [[ $? -eq 0 ]]; then
 		log "found metadata key: \"${mdata_key}\" value: \"${mdata_value}\""
-		if gsed -i "/^${config_var}=/s/${config_var}.*/${config_var}=${mdata_value}/" "${config_file}"; then
+		if [[ -z "${mdata_value}" ]]; then
+			log "empty metadata value for key \"${mdata_key}\" -> commenting out \"${config_var}\"!"
+			config_value="#${config_var}="
+		else
+			config_value="${config_var}=${mdata_value}"
+		fi
+		if gsed -i "/^${config_var}=/s/${config_var}.*/${config_value}/" "${config_file}"; then
 			log "set ${config_var}=${mdata_value} in ${config_file}"
 		else
 			log "failed to set ${config_var}=${mdata_value} in ${config_file}"

--- a/ansible/roles/pdns-recursor/defaults/main.yml
+++ b/ansible/roles/pdns-recursor/defaults/main.yml
@@ -16,3 +16,6 @@ recursor_packetcache_ttl: 3600
 
 recursor_local_address: "127.0.0.1"
 recursor_local_port: "5353"
+
+recursor_forward_zones: []
+recursor_forward_zones_recurse: []

--- a/ansible/roles/pdns-recursor/templates/recursor.conf.j2
+++ b/ansible/roles/pdns-recursor/templates/recursor.conf.j2
@@ -88,6 +88,7 @@ config-dir={{ recursor_config_dir }}
 # forward-zones	Zones for which we forward queries, comma separated domain=ip pairs
 #
 # forward-zones=
+{% if recursor_forward_zones %}forward-zones={{ recursor_forward_zones | join(',') }}{% endif %}
 
 #################################
 # forward-zones-file	File with (+)domain=ip pairs for forwarding
@@ -98,6 +99,7 @@ config-dir={{ recursor_config_dir }}
 # forward-zones-recurse	Zones for which we forward queries with recursion bit, comma separated domain=ip pairs
 #
 # forward-zones-recurse=
+{% if recursor_forward_zones_recurse %}forward-zones={{ recursor_forward_zones_recurse | join(',') }}{% endif %}
 
 #################################
 # hint-file	If set, load root hints from this file

--- a/ansible/roles/pdns-recursor/templates/recursor.conf.j2
+++ b/ansible/roles/pdns-recursor/templates/recursor.conf.j2
@@ -99,7 +99,7 @@ config-dir={{ recursor_config_dir }}
 # forward-zones-recurse	Zones for which we forward queries with recursion bit, comma separated domain=ip pairs
 #
 # forward-zones-recurse=
-{% if recursor_forward_zones_recurse %}forward-zones={{ recursor_forward_zones_recurse | join(',') }}{% endif %}
+{% if recursor_forward_zones_recurse %}forward-zones-recurse={{ recursor_forward_zones_recurse | join(',') }}{% endif %}
 
 #################################
 # hint-file	If set, load root hints from this file

--- a/ansible/templates/usb/scripts/headnode.sh.j2
+++ b/ansible/templates/usb/scripts/headnode.sh.j2
@@ -191,7 +191,7 @@ function _build_vmmanifest() {
 				-e "s|@MON_IP@|${MON_IP}|" \
 				-e "s|@ROOT_AUTHORIZED_KEYS@|${ROOT_AUTHORIZED_KEYS}|" \
 				-e "s|@PGSQL_PDNS_PASSWORD@|${PGSQL_PDNS_PASSWORD}|" \
-				-e "s|@PDNS_RECURSOR_FORWARDERS@|.=${DNS_RESOLVERS/,/;}|"
+				-e "s|@PDNS_RECURSOR_FORWARDERS@|.=${DNS_RESOLVERS/,/;}|" \
 				"${template}" > "${manifest}"
 		;;
 

--- a/ansible/templates/usb/scripts/headnode.sh.j2
+++ b/ansible/templates/usb/scripts/headnode.sh.j2
@@ -183,6 +183,12 @@ function _build_vmmanifest() {
 		;;
 
 		esdc-dns)
+			if [[ "${DNS_RESOLVERS}" =~ 8\.8\.[48]\.[48] ]]; then
+				pdns_recursor_forwarders=""
+			else
+				pdns_recursor_forwarders=".=${DNS_RESOLVERS/,/;}"
+			fi
+
 			sed -e "s|@DNS_IP@|${DNS_IP}|" \
 				-e "s|@ADMIN_NETMASK@|${ADMIN_NETMASK}|" \
 				-e "s|@ADMIN_GATEWAY@|${ADMIN_GATEWAY}|" \
@@ -191,7 +197,7 @@ function _build_vmmanifest() {
 				-e "s|@MON_IP@|${MON_IP}|" \
 				-e "s|@ROOT_AUTHORIZED_KEYS@|${ROOT_AUTHORIZED_KEYS}|" \
 				-e "s|@PGSQL_PDNS_PASSWORD@|${PGSQL_PDNS_PASSWORD}|" \
-				-e "s|@PDNS_RECURSOR_FORWARDERS@|.=${DNS_RESOLVERS/,/;}|" \
+				-e "s|@PDNS_RECURSOR_FORWARDERS@|${pdns_recursor_forwarders}|" \
 				"${template}" > "${manifest}"
 		;;
 

--- a/ansible/templates/usb/scripts/headnode.sh.j2
+++ b/ansible/templates/usb/scripts/headnode.sh.j2
@@ -190,6 +190,7 @@ function _build_vmmanifest() {
 				-e "s|@MON_IP@|${MON_IP}|" \
 				-e "s|@ROOT_AUTHORIZED_KEYS@|${ROOT_AUTHORIZED_KEYS}|" \
 				-e "s|@PGSQL_PDNS_PASSWORD@|${PGSQL_PDNS_PASSWORD}|" \
+				-e "s|@PDNS_RECURSOR_FORWARDERS@|.=${DNS_RESOLVERS/,/;}|"
 				"${template}" > "${manifest}"
 		;;
 
@@ -551,6 +552,7 @@ ZABBIX_ESDC_PASSWORD="$(random_string)"
 ZABBIX_ADMIN_USERNAME="Admin"
 ZABBIX_ADMIN_PASSWORD="$(random_string 9)"
 ZABBIX_ADMIN_EMAIL="${CONFIG_admin_email:-""}"
+DNS_RESOLVERS="${CONFIG_dns_resolvers}"
 domainname="${CONFIG_domainname:-"${CONFIG_dns_domain}"}"
 [[ -z "${domainname}" ]] && domainname="example.com"
 ZABBIX_SMTP_EMAIL="${CONFIG_sender_email:-"monitoring@${domainname}"}"

--- a/ansible/templates/usb/scripts/headnode.sh.j2
+++ b/ansible/templates/usb/scripts/headnode.sh.j2
@@ -183,7 +183,7 @@ function _build_vmmanifest() {
 		;;
 
 		esdc-dns)
-			if [[ "${DNS_RESOLVERS}" =~ 8\.8\.[48]\.[48] ]]; then
+			if [[ "${DNS_RESOLVERS}" == "8.8.8.8,8.8.4.4" ]]; then
 				pdns_recursor_forwarders=""
 			else
 				pdns_recursor_forwarders=".=${DNS_RESOLVERS/,/;}"

--- a/ansible/templates/usb/zones/esdc-dns.vmmanifest.j2
+++ b/ansible/templates/usb/zones/esdc-dns.vmmanifest.j2
@@ -31,6 +31,7 @@
     "org.erigones:pgsql_user": "{{ esdc_mgmt.pgsql_pdns.user }}",
     "org.erigones:pgsql_password": "@PGSQL_PDNS_PASSWORD@",
     "org.erigones:pgsql_dbname": "{{ esdc_mgmt.pgsql_pdns.name }}",
+    "org.erigones:recursor_forwarders": "@PDNS_RECURSOR_FORWARDERS@",
     "org.erigones:zabbix_ip": "@MON_IP@",
     "root_authorized_keys": "@ROOT_AUTHORIZED_KEYS@"
   },

--- a/ansible/vars/build/os/esdc-dns.yml
+++ b/ansible/vars/build/os/esdc-dns.yml
@@ -8,6 +8,9 @@ pdns_db_user: "@PGSQL_USER@"
 pdns_db_password: "@PGSQL_PASSWORD@"
 pdns_allow_recursion: "0.0.0.0/0"
 
+recursor_forward_zones_recurse:
+  - "@PDNS_RECURSOR_FORWARDERS@"
+
 zbx_agent_Server: "@SERVER@"
 zbx_agent_UserParameter:
   - "smf.maintenance,/usr/bin/svcs -x | grep -c svc:/"

--- a/docs/appliances.rst
+++ b/docs/appliances.rst
@@ -171,6 +171,7 @@ Changelog
 
 - Built from new `base-64-es`_ with 2016Q4 pkgsrc - `#36 <https://github.com/erigones/esdc-factory/issues/36>`__
 - Fixed problem where the pdns service goes to maintenance state when DB is not reachable - `#48 <https://github.com/erigones/esdc-factory/issues/48>`__
+- Added new metadata parameter: `org.erigones:recursor_forwarders` - `#60 <https://github.com/erigones/esdc-factory/issues/60>`__
 
 2.5.3
 ~~~~~

--- a/docs/appliances.rst
+++ b/docs/appliances.rst
@@ -161,6 +161,7 @@ The image supports following metadata (in addition to `base-64-es`_ image metada
 * **org.erigones:pgsql_user**: ``gpgsql-user`` parameter in pdns.conf.
 * **org.erigones:pgsql_password**: ``gpgsql-password`` parameter in pdns.conf.
 * **org.erigones:pgsql_dbname**: ``gpgsql-dbname`` parameter in pdns.conf.
+* **org.erigones:recursor_forwarders**: sets the ``forward-zones-recurse=.=<metadata-value>`` parameter in recursor.conf.
 
 Changelog
 ---------

--- a/docs/usb-image.rst
+++ b/docs/usb-image.rst
@@ -36,6 +36,7 @@ Changelog
 - Updated zabbix agent to 3.0.9 [monitoring-2016Q4-20170510] - `#36 <https://github.com/erigones/esdc-factory/issues/36>`__
 - Updated pkgsrc to 2016Q4 in local archive [local-2016Q4-20170510] - `#36 <https://github.com/erigones/esdc-factory/issues/36>`__
 - Updated SystemRescueCd to version 5.0.2 - commit `83a5edb <https://github.com/erigones/esdc-factory/commit/83a5edb54868220cd6052afd0c04285b8fa2a42e>`__
+- Updated first compute node installer to set recursion forwarders in esdc-dns according to DNS resolvers - `#60 <https://github.com/erigones/esdc-factory/issues/60>`__
 
 
 2.5.3 (released on 2017-05-16)


### PR DESCRIPTION
The recursion forwarders will be configured according to DNS resolvers, which were set during installation.
Added new esdc-mon mdata: `org.erigones:recursor_forwarders`.