### PR TITLE
Fixed network configuration when installed on HDD - closes #65

### DIFF
--- a/ansible/templates/usb/scripts/prompt-config.sh.j2
+++ b/ansible/templates/usb/scripts/prompt-config.sh.j2
@@ -1258,6 +1258,9 @@ setup_datasets()
 # in order to support network/physical configuration from usbkey/config.
 
 > /etc/dladm/datalink.conf
+> /etc/dladm/flowadm.conf
+> /etc/dladm/flowprop.conf
+> /etc/ipadm/ipadm.conf
 EOF
 		chmod +x "${TMPROOT}/lib/svc/method/net-cleanup"
 

--- a/ansible/templates/usb/scripts/prompt-config.sh.j2
+++ b/ansible/templates/usb/scripts/prompt-config.sh.j2
@@ -1250,22 +1250,33 @@ setup_datasets()
 		echo "7.0" > ${TMPROOT}/.smartdc_version
 
 		# Issue esdc-factory#65
-		cat > "${TMPROOT}/lib/svc/manifest/network/datalink-cleanup.xml" <<EOF
+		cat > "${TMPROOT}/lib/svc/method/net-cleanup" <<EOF
+#!/sbin/sh
+#
+# This is a simple script that cleans up persistent network configuration
+# just after the system boots. This is only required for installation to HDD
+# in order to support network/physical configuration from usbkey/config.
+
+> /etc/dladm/datalink.conf
+EOF
+		chmod +x "${TMPROOT}/lib/svc/method/net-cleanup"
+
+		cat > "${TMPROOT}/lib/svc/manifest/network/network-cleanup.xml" <<EOF
 <?xml version='1.0'?>
 <!DOCTYPE service_bundle SYSTEM '/usr/share/lib/xml/dtd/service_bundle.dtd.1'>
 <!--
- This is a simple script that cleans up persistent datalink configuration
+ This is a simple script that cleans up persistent network configuration
  just after the system boots. This is only required for installation to HDD
  in order to support network/physical configuration from usbkey/config.
 -->
-<service_bundle type='manifest' name='datalink-cleanup'>
-  <service name='network/datalink-cleanup' type='service' version='0'>
+<service_bundle type='manifest' name='network-cleanup'>
+  <service name='network/cleanup' type='service' version='0'>
     <create_default_instance enabled='true'/>
     <single_instance/>
     <dependent name='datalink-management' restart_on='none' grouping='require_all'>
       <service_fmri value='svc:/network/datalink-management'/>
     </dependent>
-    <exec_method name='start' type='method' exec='/bin/rm -f /etc/dladm/datalink.conf' timeout_seconds='10'/>
+    <exec_method name='start' type='method' exec='/lib/svc/method/net-cleanup' timeout_seconds='10'/>
     <exec_method name='stop' type='method' exec=':true' timeout_seconds='3'/>
     <property_group name="startd" type="framework">
       <propval name="duration" type="astring" value="transient" />

--- a/ansible/templates/usb/scripts/prompt-config.sh.j2
+++ b/ansible/templates/usb/scripts/prompt-config.sh.j2
@@ -1248,6 +1248,33 @@ setup_datasets()
 
 		echo 'boot-args="-B smartos=true,computenode=true"' >> ${TMPROOT}/boot/loader.conf
 		echo "7.0" > ${TMPROOT}/.smartdc_version
+
+		# Issue esdc-factory#65
+		cat > "${TMPROOT}/lib/svc/manifest/network/datalink-cleanup.xml" <<EOF
+<?xml version='1.0'?>
+<!DOCTYPE service_bundle SYSTEM '/usr/share/lib/xml/dtd/service_bundle.dtd.1'>
+<!--
+ This is a simple script that cleans up persistent datalink configuration
+ just after the system boots. This is only required for installation to HDD
+ in order to support network/physical configuration from usbkey/config.
+-->
+<service_bundle type='manifest' name='datalink-cleanup'>
+  <service name='network/datalink-cleanup' type='service' version='0'>
+    <create_default_instance enabled='true'/>
+    <single_instance/>
+    <dependent name='datalink-management' restart_on='none' grouping='require_all'>
+      <service_fmri value='svc:/network/datalink-management'/>
+    </dependent>
+    <exec_method name='start' type='method' exec='/bin/rm -f /etc/dladm/datalink.conf' timeout_seconds='10'/>
+    <exec_method name='stop' type='method' exec=':true' timeout_seconds='3'/>
+    <property_group name="startd" type="framework">
+      <propval name="duration" type="astring" value="transient" />
+      <propval name="ignore_error" type="astring" value="core,signal" />
+    </property_group>
+    <stability value='Unstable'/>
+  </service>
+</service_bundle>
+EOF
 	fi
 }
 

--- a/docs/usb-image.rst
+++ b/docs/usb-image.rst
@@ -24,6 +24,7 @@ Changelog
 
 - Added automatic discovery of configuration database IP address during installation - `#64 <https://github.com/erigones/esdc-factory/issues/64>`__
 - Updated zabbix agent to 3.0.10 [monitoring-2016Q4-20170731] - commit `b9e16b5 <https://github.com/erigones/esdc-factory/commit/b9e16b542838418e9a4b0b10b71b9e3a298fc2ec>`__
+- Fixed network configuration when installed on HDD - `#65 <https://github.com/erigones/esdc-factory/issues/65>`__
 
 
 2.6.0 (released on 2017-07-21)


### PR DESCRIPTION
Added simple service that cleans up persistent datalink configuration
just after the system boots. This is only required for installation to HDD
in order to support network/physical configuration from usbkey/config.

+ Close #65 
+ PR https://github.com/erigones/esdc-ce/pull/215