### PR TITLE
Added config to customize rabbitmq-server systemd service

### DIFF
--- a/ansible/roles/esdc-mgmt/files/rabbitmq/custom.conf
+++ b/ansible/roles/esdc-mgmt/files/rabbitmq/custom.conf
@@ -1,0 +1,2 @@
+[Service]
+Restart=on-failure

--- a/ansible/roles/esdc-mgmt/tasks/rabbitmq.yml
+++ b/ansible/roles/esdc-mgmt/tasks/rabbitmq.yml
@@ -10,6 +10,23 @@
               state=present
               create=yes
 
+- name: Create systemd rabbitmq-server directory for custom configs
+  file: path=/etc/systemd/system/rabbitmq-server.service.d
+        owner=root
+        group=root
+        mode=0755
+        state=directory
+
+- name: Copy custom rabbitmq-server config file to /etc/systemd/system/rabbitmq-server.service.d
+  copy: src=rabbitmq/custom.conf
+        dest=/etc/systemd/system/rabbitmq-server.service.d/custom.conf
+        owner=root
+        group=root
+        mode=0644
+
+- name: Reload systemd configuration files
+  shell: systemctl daemon-reload
+
 - name: Start rabbitmq-server and enable at boot
   service: name=rabbitmq-server enabled=yes state=started
 

--- a/docs/appliances.rst
+++ b/docs/appliances.rst
@@ -391,6 +391,7 @@ Changelog
 
 - Added `org.erigones:pgsql_mgmt_mon_password` metadata parameter - `#72 <https://github.com/erigones/esdc-factory/issues/72>`__
 - Added bash-completion package - commit `420d304 <https://github.com/erigones/esdc-factory/commit/420d3042044db9b5557051ad21d66cf6ea66f882>`__
+- Modified rabbitmq-server.service to be restarted upon failure - `#71 <https://github.com/erigones/esdc-factory/issues/71>`__
 
 2.6.3
 ~~~~~


### PR DESCRIPTION
rabbitmq-server will be restarted automatically if it fails

Related to issue #71 