### PR TITLE
Disabled cloud-init network configuration

### DIFF
--- a/ansible/files/centos-image-tools/prepare-image
+++ b/ansible/files/centos-image-tools/prepare-image
@@ -111,8 +111,11 @@ ONBOOT=yes
 NAME=loopback
 EOF
 
-cat > /etc/sysconfig/network-scripts/ifcfg-net0 << EOF
-DEVICE="net0"
+# Although there is an automatic NIC configuration script in rc.local,
+# this network script is required to ensure that the main NIC is up ASAP
+# (This is important for esdc-mgmt and usually VMs have at least one NIC)
+cat > /etc/sysconfig/network-scripts/ifcfg-eth0 << EOF
+DEVICE="eth0"
 DEVICETYPE="eth"
 ONBOOT="yes"
 BOOTPROTO="dhcp"

--- a/ansible/roles/cloud-init/files/CentOS-6/cloud.cfg
+++ b/ansible/roles/cloud-init/files/CentOS-6/cloud.cfg
@@ -10,6 +10,9 @@ cloud_init_modules:
 cloud_config_modules:
  - set-passwords
 
+network:
+  config: disabled
+
 system_info:
   distro: rhel
   paths:

--- a/ansible/roles/cloud-init/files/CentOS-7/cloud.cfg
+++ b/ansible/roles/cloud-init/files/CentOS-7/cloud.cfg
@@ -12,6 +12,9 @@ cloud_init_modules:
 cloud_config_modules:
  - set-passwords
 
+network:
+  config: disabled
+
 growpart:
   mode: auto
   devices: ['/']

--- a/ansible/templates/centos-6/ks.cfg.j2
+++ b/ansible/templates/centos-6/ks.cfg.j2
@@ -145,6 +145,7 @@ for iface in ${interfaces[@]}; do
     ifdown ${iface}
 
     echo "DEVICE=\"${iface}\"" > ${config}
+    echo "TYPE=\"Ethernet\"" >> ${config
     echo "ONBOOT=\"yes\"" >> ${config}
     echo "BOOTPROTO=\"dhcp\"" >> ${config}
 

--- a/ansible/templates/centos-7/ks.cfg.j2
+++ b/ansible/templates/centos-7/ks.cfg.j2
@@ -165,6 +165,7 @@ for iface in ${interfaces[@]}; do
     ifdown ${iface}
 
     echo "DEVICE=\"${iface}\"" > ${config}
+    echo "TYPE=\"Ethernet\"" >> ${config}
     echo "ONBOOT=\"yes\"" >> ${config}
     echo "BOOTPROTO=\"dhcp\"" >> ${config}
 

--- a/ansible/vars/build/os/contrib-gitlab-ce.yml
+++ b/ansible/vars/build/os/contrib-gitlab-ce.yml
@@ -14,5 +14,5 @@ firewall_allowed_tcp_ports:
 selinux_permissive_domains:
   - zabbix_agent_t
 
-gitlab_ce_version: "9.5.5"
-gitlab_ce_checksum: "d40f20eaea1ec4fa0cfdf3037e0ae0edd47f2905"  # sha1
+gitlab_ce_version: "9.5.6"
+gitlab_ce_checksum: "815733529d0ec5da6c47928c46503ed20fd860d7"  # sha1

--- a/ansible/vars/build/os/esdc-mgmt.yml
+++ b/ansible/vars/build/os/esdc-mgmt.yml
@@ -70,16 +70,6 @@ firewall_allowed_tcp_ports:
     iface: eth0
   - port: 10050
     iface: eth0
-  - port: 22
-    iface: net0
-  - port: 5672
-    iface: net0
-  - port: 6379
-    iface: net0
-  - port: 6432
-    iface: net0
-  - port: 10050
-    iface: net0
 
 sudo_users:
   - user: erigones

--- a/docs/appliances.rst
+++ b/docs/appliances.rst
@@ -409,7 +409,7 @@ Changelog
 2.6.5
 ~~~~~
 
-- Version bump.
+- Disabled cloud-init network configuration - `#80 <https://github.com/erigones/esdc-factory/issues/80>`__
 
 2.6.4
 ~~~~~
@@ -512,6 +512,7 @@ Changelog
 ~~~~~
 
 - Added t_svc-db-ha template for monitoring HA status of the PostgreSQL cluster - `#79 <https://github.com/erigones/esdc-factory/issues/79>`__
+- Disabled cloud-init network configuration - `#80 <https://github.com/erigones/esdc-factory/issues/80>`__
 
 2.6.4
 ~~~~~

--- a/docs/contrib/centos-6.rst
+++ b/docs/contrib/centos-6.rst
@@ -11,10 +11,11 @@ The image supports following metadata:
 Changelog
 ---------
 
-20170922
+20170930
 ~~~~~~~~
 
 - Version bump.
+- Disabled cloud-init network configuration - `#80 <https://github.com/erigones/esdc-factory/issues/80>`__
 
 20170724
 ~~~~~~~~

--- a/docs/contrib/centos-7-desktop.rst
+++ b/docs/contrib/centos-7-desktop.rst
@@ -24,12 +24,12 @@ The image supports following metadata:
 Changelog
 ---------
 
-20170922
+20170930
 ~~~~~~~~
 
 - Renamed image from ``centos7-desktop`` to ``centos-7-desktop``.
 - Version bump to CentOS 7.4 (1708).
-- Fixed critical NIC naming problem, which could lead to `network being down in VMs after update of cloud-init or CentOS <https://github.com/erigones/esdc-ce/wiki/Known-Issues#network-down-in-vms-after-update-of-cloud-init-or-centos>`__.
+- Disabled cloud-init network configuration, which could lead to `network being down in VMs after update of cloud-init or CentOS <https://github.com/erigones/esdc-ce/wiki/Known-Issues#network-down-in-vms-after-update-of-cloud-init-or-centos>`__  - `#80 <https://github.com/erigones/esdc-factory/issues/80>`__
 
 20170724
 ~~~~~~~~

--- a/docs/contrib/centos-7.rst
+++ b/docs/contrib/centos-7.rst
@@ -12,11 +12,11 @@ The image supports following metadata:
 Changelog
 ---------
 
-20170922
+20170930
 ~~~~~~~~
 
 - Version bump to CentOS 7.4 (1708).
-- Fixed critical NIC naming problem, which could lead to `network being down in VMs after update of cloud-init or CentOS <https://github.com/erigones/esdc-ce/wiki/Known-Issues#network-down-in-vms-after-update-of-cloud-init-or-centos>`__.
+- Disabled cloud-init network configuration, which could lead to `network being down in VMs after update of cloud-init or CentOS <https://github.com/erigones/esdc-ce/wiki/Known-Issues#network-down-in-vms-after-update-of-cloud-init-or-centos>`__  - `#80 <https://github.com/erigones/esdc-factory/issues/80>`__
 
 20170724
 ~~~~~~~~

--- a/docs/contrib/gitlab-ce.rst
+++ b/docs/contrib/gitlab-ce.rst
@@ -18,12 +18,12 @@ The image supports following metadata:
 Changelog
 ---------
 
-20170922
+20170930
 ~~~~~~~~
 
 - CentOS 7.4 (1708)
-- GitLab CE 9.5.5
-- Fixed critical NIC naming problem, which could lead to `network being down in VMs after update of cloud-init or CentOS <https://github.com/erigones/esdc-ce/wiki/Known-Issues#network-down-in-vms-after-update-of-cloud-init-or-centos>`__.
+- GitLab CE 9.5.6
+- Disabled cloud-init network configuration, which could lead to `network being down in VMs after update of cloud-init or CentOS <https://github.com/erigones/esdc-ce/wiki/Known-Issues#network-down-in-vms-after-update-of-cloud-init-or-centos>`__  - `#80 <https://github.com/erigones/esdc-factory/issues/80>`__
 
 20170724
 ~~~~~~~~


### PR DESCRIPTION
Related to https://github.com/erigones/esdc-ce/wiki/Known-Issues#network-down-in-vms-after-update-of-cloud-init-or-centos