### PR TITLE
Fixed timezone for the Zabbix frontend

### DIFF
--- a/ansible/roles/zabbix-server/tasks/main.yml
+++ b/ansible/roles/zabbix-server/tasks/main.yml
@@ -37,7 +37,7 @@
     - { option: post_max_size,          value: 16M }
     - { option: upload_max_filesize,    value: 2M }
     - { option: max_input_time,         value: 300 }
-    - { option: date.timezone,          value: Europe/Bratislava, section: Date }
+    - { option: date.timezone,          value: UTC, section: Date }
 
 - name: Update /etc/zabbix/zabbix_server.conf
   lineinfile: dest="/etc/zabbix/zabbix_server.conf"

--- a/docs/appliances.rst
+++ b/docs/appliances.rst
@@ -587,6 +587,7 @@ Changelog
 ~~~~~
 
 - Fixed monitoring items of erigonesd mgmt worker - `#98 <https://github.com/erigones/esdc-factory/issues/98>`__
+- Fixed timezone of the Zabbix frontend - `#106 <https://github.com/erigones/esdc-factory/issues/106>`__
 
 2.6.7
 ~~~~~


### PR DESCRIPTION
The timezone must be the same as the OS timezone, which is UTC.