### PR TITLE
Fixed /etc/rc.d/rc.local permissions in CentOS appliances

### DIFF
--- a/ansible/roles/rc-scripts/tasks/main.yml
+++ b/ansible/roles/rc-scripts/tasks/main.yml
@@ -13,3 +13,6 @@
 
 - name: Enable rc-scripts systemd service
   shell: systemctl enable rc-scripts.service
+
+- name: Fix /etc/rc.d/rc.local permissions
+  file: dest=/etc/rc.d/rc.local mode=u+x

--- a/docs/appliances.rst
+++ b/docs/appliances.rst
@@ -469,7 +469,7 @@ Changelog
 2.7.0
 ~~~~~
 
-- Version bump.
+- Fixed /etc/rc.d/rc.local permissions - `#109 <https://github.com/erigones/esdc-factory/issues/109>`__
 
 2.6.7
 ~~~~~
@@ -588,6 +588,7 @@ Changelog
 
 - Fixed monitoring items of erigonesd mgmt worker - `#98 <https://github.com/erigones/esdc-factory/issues/98>`__
 - Fixed timezone of the Zabbix frontend - `#106 <https://github.com/erigones/esdc-factory/issues/106>`__
+- Fixed /etc/rc.d/rc.local permissions - `#109 <https://github.com/erigones/esdc-factory/issues/109>`__
 
 2.6.7
 ~~~~~


### PR DESCRIPTION
`/etc/rc.d/rc.local` must be executable so that network interface autoconfiguration works after adding/removing a NIC.