### PR TITLE
bump pkgsrc to 2018Q4, upgrade platform, archives and other deps

### DIFF
--- a/ansible/group_vars/build/base.yml
+++ b/ansible/group_vars/build/base.yml
@@ -38,8 +38,8 @@ builder_base_centos_imgfile: base-centos-7-latest.zfs.gz
 builder_base_centos_imgmanifest_url: "{{ builder.appliance.url }}/base-centos-7/{{ builder_base_centos_imgmanifest }}"
 builder_base_centos_imgfile_url: "{{ builder.appliance.url }}/base-centos-7/{{ builder_base_centos_imgfile }}"
 
-pkgsrc_version: 17.4.0
-pkgin_release: 2017Q4
+pkgsrc_version: 18.4.0
+pkgin_release: 2018Q4
 builder_base_zone_imgmanifest: "base-64-es-{{ pkgsrc_version }}.imgmanifest"
 builder_base_zone_imgfile: "base-64-es-{{ pkgsrc_version }}.zfs.gz"
 builder_base_zone_imgmanifest_url: "{{ builder.appliance.url }}/base-64-es/{{ builder_base_zone_imgmanifest }}"

--- a/ansible/group_vars/build/usb-deps.yml
+++ b/ansible/group_vars/build/usb-deps.yml
@@ -1,34 +1,34 @@
 builder_platform_url: 'http://download.erigones.org/esdc/factory/platform'
 builder_platform:
   - name: 'boot'
-    version: '20180318T095138Z'
+    version: '20190212T235700Z'
     desc: 'SmartOS grub boot loader'
     link: 'boot-latest'
   - name: 'platform'
-    version: '20180318T095138Z'
+    version: '20190212T235700Z'
     desc: 'SmartOS kernel and boot_archive'
     link: 'platform-latest'
 
 builder_archives_url: 'http://download.erigones.org/esdc/factory/archives'
 builder_archives:
   - name: 'monitoring'
-    version: '2017Q4-20180410'
+    version: '2018Q4-20190217'
     desc: '/opt/zabbix directory on hypervisor'
     link: 'monitoring-latest'
   - name: 'local'
-    version: '2017Q4-20180112'
+    version: '2018Q4-20190217'
     desc: '/opt/local directory on hypervisor'
     link: 'local-latest'
   - name: 'opt-custom'
-    version: '2017Q4-20180506'
+    version: '2018Q4-20190217'
     desc: '/opt/custom directory on hypervisor'
     link: 'opt-custom-latest'
 
 builder_isos_url: ''
 builder_isos:
   - name: 'rescuecd'
-    version: '5.0.4'
-    url: 'http://downloads.sourceforge.net/project/systemrescuecd/sysresccd-x86/5.0.4/systemrescuecd-x86-5.0.4.iso?use_mirror=netcologne'
+    version: '5.3.2'
+    url: 'http://downloads.sourceforge.net/project/systemrescuecd/sysresccd-x86/5.3.2/systemrescuecd-x86-5.3.2.iso?use_mirror=netcologne'
     link: 'rescuecd-latest'
 
 bootstrap_local_archive: "{{ bootstrap|default(false) }}"

--- a/ansible/host_vars/builder/usb-image.yml
+++ b/ansible/host_vars/builder/usb-image.yml
@@ -1,12 +1,12 @@
-usb_tmp_dir: "{{ builder_tmp_dir | mandatory }}"
-usb_tmp_stage: "{{ usb_tmp_dir }}/esdc-usb-stage"
-usb_tmp_mountpoint: "{{ usb_tmp_dir }}/esdc-usb-image"
-usb_tmp_image: "{{ usb_tmp_dir }}/esdc-usb.img"
 usb_type: "hn"  # "hn" or "cn"
+usb_tmp_dir: "{{ builder_tmp_dir | mandatory }}"
+usb_tmp_stage: "{{ usb_tmp_dir }}/esdc-usb-stage-{{ usb_type }}"
+usb_tmp_mountpoint: "{{ usb_tmp_dir }}/esdc-usb-image-{{ usb_type }}"
+usb_tmp_image: "{{ usb_tmp_dir }}/esdc-usb-{{ usb_type }}-{{ version }}.img"
 usb_root_pw: "$5$2HOHRnK3$NvLlm.1KQBbB0WjoP7xcIwGnllhzp2HnT.mDO7DpxYA"  # root
 
-platform_version: "20180318T095138Z"
-platform_upstream_version: "release-20180315"
+platform_version: "20190212T235700Z"
+platform_upstream_version: "release-20190230"
 platform_os_archive: "{{ builder.platform.dir }}/platform-{{ platform_version }}.tgz"
 platform_boot_archive: "{{ builder.platform.dir }}/boot-{{ platform_version }}.tgz"
 

--- a/ansible/roles/esdc-mgmt/tasks/esdc.yml
+++ b/ansible/roles/esdc-mgmt/tasks/esdc.yml
@@ -37,15 +37,17 @@
     - libjpeg-devel
     - patch
 
-- name: Download GeoIP database
-  get_url: url="http://geolite.maxmind.com/download/geoip/database/GeoLiteCountry/GeoIP.dat.gz"
-           dest="/tmp/GeoIP.dat.gz"
-
-- name: Extract GeoIP database
-  shell: gzip -cd /tmp/GeoIP.dat.gz > /usr/share/GeoIP/GeoIP.dat
-
-- name: Remove downloaded GeoIP database
-  shell: rm -f /tmp/GeoIP.dat.gz
+# GeoIP DB is no longer downloadable and the DB was updated in rpm itself
+#- name: Download GeoIP database
+#  #get_url: url="http://geolite.maxmind.com/download/geoip/database/GeoLiteCountry/GeoIP.dat.gz"
+#  get_url: url="{{ build_base_url }}/platform-janci/GeoIP.dat.gz"
+#           dest="/tmp/GeoIP.dat.gz"
+#
+#- name: Extract GeoIP database
+#  shell: gzip -cd /tmp/GeoIP.dat.gz > /usr/share/GeoIP/GeoIP.dat
+#
+#- name: Remove downloaded GeoIP database
+#  shell: rm -f /tmp/GeoIP.dat.gz
 
 - name: Create erigones group
   group: name=erigones state=present system=yes

--- a/ansible/roles/esdc-node/tasks/main.yml
+++ b/ansible/roles/esdc-node/tasks/main.yml
@@ -12,7 +12,7 @@
     - python27
     - py27-virtualenv
     - git-base
-    - gcc49
+    - gcc7
     - gmake
     - autoconf
 
@@ -41,7 +41,7 @@
 - name: Build esDC compute node software (que)
   shell: /opt/erigones/bin/ctl.sh build --node
   environment:
-    PATH: "{{ ansible_env.PATH }}:/opt/local/gcc49/bin"
+    PATH: "{{ ansible_env.PATH }}:/opt/local/gcc7/bin"
 
 - name: Cleanup esDC virtualenvs
   shell: /opt/erigones/bin/ctl.sh clean_envs

--- a/ansible/roles/pkgin/defaults/main.yml
+++ b/ansible/roles/pkgin/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 pkgin_mirror: http://mirror.erigones.com
-pkgin_release: 2015Q4
+pkgin_release: 2018Q4
 pkgin_arch: x86_64
 
 pkgin_repositories:

--- a/ansible/tasks/build/archives/create-local-archive.yml
+++ b/ansible/tasks/build/archives/create-local-archive.yml
@@ -19,10 +19,10 @@
 - name: Update system packages
   shell: pkgin -y full-upgrade
 
-# esDC requirements: gcc49 gmake autoconf git-base python27 py27-virtualenv
+# esDC requirements: gcc7 gmake autoconf git-base python27 py27-virtualenv
 # glib2 is required by qemu-img
 - name: Install esDC OS dependencies
-  shell: pkgin -y install gcc49 gmake autoconf git-base python27 py27-virtualenv glib2 patch
+  shell: pkgin -y install gcc7 gmake autoconf git-base python27 py27-virtualenv glib2 patch
 
 - name: Install requirements for desktop VM redirection
   shell: pkgin -y install modular-xorg-server xf86-video-vesa xf86-input-keyboard xf86-input-mouse xhost xauth rdesktop dejavu-ttf coreutils xinit

--- a/ansible/vars/build/os/archive-monitoring.yml
+++ b/ansible/vars/build/os/archive-monitoring.yml
@@ -7,4 +7,4 @@ pkg_ext: ".tar.gz"
 pkg_link: "{{ pkg_base_name }}-latest"
 pkg_link_exts:
   - "{{ pkg_ext }}"
-zabbix_agent_version: 3.0.16
+zabbix_agent_version: 3.0.24

--- a/ansible/vars/build/vm/base-64-es.yml
+++ b/ansible/vars/build/vm/base-64-es.yml
@@ -7,7 +7,7 @@ builder_dir: "{{ builder.appliance.dir }}/base-64-es"
 zone_brand: joyent
 zone_dns_domain: local
 zone_uuid: b442c858-f254-4a1f-a4f5-8fce46913ca6
-zone_image_uuid: 390639d4-f146-11e7-9280-37ae5c6d53d4 # base-64-lts 17.4.0
+zone_image_uuid: c193a558-1d63-11e9-97cf-97bb3ee5c14f # base-64-lts 18.4.0
 zone_hostname: "{{ image_name }}"
 zone_nic_0_ip: "{{ build_ips.base64 | default(build_ip) }}"
 zone_delegate_dataset: false

--- a/ansible/vars/build/vm/base-centos-7.yml
+++ b/ansible/vars/build/vm/base-centos-7.yml
@@ -8,9 +8,9 @@ builder_download_url: "{{ builder.appliance.url }}/base-centos-7/_build"
 centos_mirror: "{{ builder_centos_mirror }}/7/os/x86_64/images/pxeboot"
 centos_files:
   - file: vmlinuz
-    sha256sum: 8ede7f8d3c8f5e72f1a84713ad59b7b39211ea1af8887389cb50a189df937c6f
+    sha256sum: 225fd77bec0f02dd6abba7ad39332ffededb7778d8b01ba3bb921027b468eef8
   - file: initrd.img
-    sha256sum: 5c71c0494620325c1ee919b44ac4ed4518fb43443bbf0474ff75951ea140c89c
+    sha256sum: 38ac551a17a33410c456d8bde4c9c25464e061239906b2d316882474daeec0ea
 zone_brand: kvm
 zone_vnc_port: "{{ build_vnc_ports.base_centos7 | default(build_vnc_port) | mandatory }}"
 zone_uuid: 316ae519-a88e-49e1-8eb3-d55d36aecbbf

--- a/docs/usb-image.rst
+++ b/docs/usb-image.rst
@@ -29,7 +29,7 @@ Released on `TBA`
 - Bumped default gcc version from 4.9 to 7 - `#126 <https://github.com/erigones/esdc-factory/pull/126>`
 - Allow parralel builds of ``hn`` and ``cn`` usb images - `#126 <https://github.com/erigones/esdc-factory/pull/126>`
 - Fixed CPU monitoring script - `esdc-ce#375 <https://github.com/erigones/esdc-ce/issues/375>`__
-- Fixes ``ike`` service not enabled after reboot - `#124 <https://github.com/erigones/esdc-factory/pull/124>`__
+- Fixed ``ike`` service not enabled after reboot - `#124 <https://github.com/erigones/esdc-factory/pull/124>`__
 
 
 3.0.0

--- a/docs/usb-image.rst
+++ b/docs/usb-image.rst
@@ -19,12 +19,17 @@ Both USB images are assembled together from these components:
 Changelog
 ~~~~~~~~~
 
-4.0.0
+4.0
 =====
 Released on `TBA`
 
 - Updated to a new platform version - `<TBD>` from upstream/release-`<TBD>`
+- Updated pkgsrc version to 2018Q4 - `#126 <https://github.com/erigones/esdc-factory/pull/126>`
+- Updated archives - `#126 <https://github.com/erigones/esdc-factory/pull/126>`
+- Bumped default gcc version from 4.9 to 7 - `#126 <https://github.com/erigones/esdc-factory/pull/126>`
+- Allow parralel builds of ``hn`` and ``cn`` usb images - `#126 <https://github.com/erigones/esdc-factory/pull/126>`
 - Fixed CPU monitoring script - `esdc-ce#375 <https://github.com/erigones/esdc-ce/issues/375>`__
+- Fixes ``ike`` service not enabled after reboot - `#124 <https://github.com/erigones/esdc-factory/pull/124>`__
 
 
 3.0.0


### PR DESCRIPTION
Plus allow parralel builds of `hn` and `cn`.