### PR TITLE
add LD_LIBRARY_PATH to zabbix agent SMF

### DIFF
--- a/ansible/files/archives/monitoring/opt/custom/smf/zabbix-agent.xml
+++ b/ansible/files/archives/monitoring/opt/custom/smf/zabbix-agent.xml
@@ -20,6 +20,7 @@
                 <method_credential user="root" group="bin"/>
                 <method_environment>
                         <envvar name="PATH" value="/usr/bin:/sbin:/usr/sbin:/opt/local/bin:/opt/zabbix/sbin:/usr/sfw/bin" />
+                        <envvar name="LD_LIBRARY_PATH" value="/opt/local/lib" />
                 </method_environment>
         </method_context>
      </exec_method>


### PR DESCRIPTION
`zabbix_agentd` uses some libs from `/opt/local`. Therefore `/opt/local/lib` should be included in the SMF manifest of zabbix agent to make sure it always finds required files. 
This is required for `2018Q4` repo.