### PR TITLE
build 4.0-beta2 usb images

### DIFF
--- a/ansible/group_vars/build/usb-deps.yml
+++ b/ansible/group_vars/build/usb-deps.yml
@@ -1,11 +1,11 @@
 builder_platform_url: 'http://download.erigones.org/esdc/factory/platform'
 builder_platform:
   - name: 'boot'
-    version: '20190212T235700Z'
+    version: '20190320T103638Z'
     desc: 'SmartOS grub boot loader'
     link: 'boot-latest'
   - name: 'platform'
-    version: '20190212T235700Z'
+    version: '20190320T103638Z'
     desc: 'SmartOS kernel and boot_archive'
     link: 'platform-latest'
 

--- a/ansible/host_vars/builder/usb-image.yml
+++ b/ansible/host_vars/builder/usb-image.yml
@@ -5,8 +5,8 @@ usb_tmp_mountpoint: "{{ usb_tmp_dir }}/esdc-usb-image-{{ usb_type }}"
 usb_tmp_image: "{{ usb_tmp_dir }}/esdc-usb-{{ usb_type }}-{{ version }}.img"
 usb_root_pw: "$5$2HOHRnK3$NvLlm.1KQBbB0WjoP7xcIwGnllhzp2HnT.mDO7DpxYA"  # root
 
-platform_version: "20190212T235700Z"
-platform_upstream_version: "release-20190230"
+platform_version: "20190320T103638Z"
+platform_upstream_version: "release-20190314"
 platform_os_archive: "{{ builder.platform.dir }}/platform-{{ platform_version }}.tgz"
 platform_boot_archive: "{{ builder.platform.dir }}/boot-{{ platform_version }}.tgz"
 

--- a/ansible/vars/build/os/base-64-es.yml
+++ b/ansible/vars/build/os/base-64-es.yml
@@ -1,4 +1,4 @@
-zbx_agent_Server: "@SERVER@"
+#zbx_agent_Server: "@SERVER@"
 zbx_agent_UserParameter:
   - "smf.maintenance,/usr/bin/svcs -x | grep -c svc:/"
   - "smf.status[*],/usr/bin/svcs -Ho state $1 2>/dev/null || echo ZBX_NOTSUPPORTED"

--- a/ansible/vars/build/os/esdc-cfgdb.yml
+++ b/ansible/vars/build/os/esdc-cfgdb.yml
@@ -1,4 +1,4 @@
-zbx_agent_Server: "@SERVER@"
+#zbx_agent_Server: "@SERVER@"
 zbx_agent_UserParameter:
   - "zookeeper.ping,echo ruok | nc -w 2 127.0.0.1 2181 | grep -c imok"
   - "smf.maintenance,/usr/bin/svcs -x | grep -c svc:/"

--- a/ansible/vars/build/os/esdc-dns.yml
+++ b/ansible/vars/build/os/esdc-dns.yml
@@ -11,7 +11,7 @@ pdns_allow_recursion: "0.0.0.0/0"
 recursor_forward_zones_recurse:
   - "@PDNS_RECURSOR_FORWARDERS@"
 
-zbx_agent_Server: "@SERVER@"
+#zbx_agent_Server: "@SERVER@"
 zbx_agent_UserParameter:
   - "smf.maintenance,/usr/bin/svcs -x | grep -c svc:/"
   - "smf.status[*],/usr/bin/svcs -Ho state $1 2>/dev/null || echo ZBX_NOTSUPPORTED"

--- a/ansible/vars/build/os/esdc-img.yml
+++ b/ansible/vars/build/os/esdc-img.yml
@@ -2,7 +2,7 @@ shipment_source:
   repo: "https://github.com/erigones/esdc-shipment.git"
   version: "{{ software_branch }}"
 
-zbx_agent_Server: "@SERVER@"
+#zbx_agent_Server: "@SERVER@"
 zbx_agent_UserParameter:
   - "shipment.ping,/usr/bin/curl -s -m3 http://127.0.0.1/ping | grep -c pong"
   - "smf.maintenance,/usr/bin/svcs -x | grep -c svc:/"

--- a/ansible/vars/build/vm/esdc-dns.yml
+++ b/ansible/vars/build/vm/esdc-dns.yml
@@ -7,6 +7,7 @@ builder_dir: "{{ builder.appliance.dir }}/esdc-dns"
 zone_brand: joyent
 zone_dns_domain: local
 zone_uuid: 4cb74eb8-8f37-4a0d-aa37-7d8f50083970
+pkgsrc_version: 17.4.0  # we need to use base-64-es 17.4.0 (until pdns gets upgraded to 4.1+)
 zone_image_uuid: "{{ (lookup('pipe', 'curl -s {{ builder_base_zone_imgmanifest_url }}') | from_json)['uuid'] }}"
 zone_hostname: dns01
 zone_nic_0_ip: "{{ build_ips.esdc_dns | default(build_ip) }}"


### PR DESCRIPTION
Creating PR just FYI.

Notes:
- `esdc-dns` image is built with `2017Q4` because of `pdns40` build issue. The rest is built with `2018Q4`.
- the platform might be considered stable but there will most probablty be at least one more build because of upstreaming of live-migration code
- the `zbx_agent_Server="@SERVER@"` variable does not seem to cooperate with newest `zabbix-agent` `v4.0.6` (refuses to start with invalid variable). But it is not necessary to set it there as it is set globally to `127.0.0.1` and re-configured by zoneinit scripts during deploy.
