### PR TITLE
fix re-adding node info into cfgdb after reinstall

### DIFF
--- a/ansible/templates/usb/scripts/computenode.sh.j2
+++ b/ansible/templates/usb/scripts/computenode.sh.j2
@@ -259,7 +259,7 @@ function pull_cfgdb_data() {
 	printf_log "%4s\n" "done"
 	printf_log "\r%-64s" "Registering compute node into cfgdb... "
 
-	_zk_noerror rmr --force "/esdc/nodes/hosts/${SYSINFO_UUID}"
+	_zk_noerror --force rmr "/esdc/nodes/hosts/${SYSINFO_UUID}"
 	_zk creater "/esdc/nodes/hosts/${SYSINFO_UUID}" "${SYSINFO_Hostname}"
 	_zk creater "/esdc/nodes/hosts/${SYSINFO_UUID}/headnode" "false"
 	_zk creater "/esdc/nodes/hosts/${SYSINFO_UUID}/hostname" "${SYSINFO_Hostname}"


### PR DESCRIPTION
When reinstalling a CN, the re-adding node info into cfgdb can fail with message like this:

```
Registering compute node into cfgdb... 
Error: cfgdb command "creater' /esdc/nodes/hosts/564dd2fa-c4f0-b1d4-98f0-80a5c2124f9f 'node02.local" failed
```

