### PR TITLE
add python3 to installed VMs

### DIFF
--- a/ansible/roles/esdc-mgmt/tasks/esdc.yml
+++ b/ansible/roles/esdc-mgmt/tasks/esdc.yml
@@ -12,6 +12,11 @@
     - GeoIP
     - python-requests
     - python-httplib2
+    - python36
+    - python36-virtualenv
+    - python36-pip
+    - python36-requests
+    - python36-httplib2
     - libxml2
     - libxslt
     - rsync
@@ -28,6 +33,7 @@
     - make
     - postgresql{{ pg_version_nodot }}-devel
     - python-devel
+    - python36-devel
     - libffi-devel
     - zlib-devel
     - libevent-devel

--- a/ansible/roles/esdc-mon/tasks/02-packages.yml
+++ b/ansible/roles/esdc-mon/tasks/02-packages.yml
@@ -4,6 +4,8 @@
   with_items:
     - python-requests
     - python-pip
+    - python36-requests
+    - python36-pip
 
 - name: Install zabbix-api-erigones (zabbix_template module)
   shell: pip install -U zabbix-api-erigones

--- a/ansible/roles/postgresql/defaults/CentOS.yml
+++ b/ansible/roles/postgresql/defaults/CentOS.yml
@@ -7,9 +7,8 @@ pg_packages:
   - "postgresql{{ pg_version_nodot }}-libs"
   - "postgresql{{ pg_version_nodot }}-server"
   - "postgresql{{ pg_version_nodot }}-contrib"
-  #- "python-psycopg2"  (revert after migration to python3)
-  # compiled for pg95:
-  - "https://download.erigones.org/rpm/python-psycopg2-dc-2.7.5-1.el7.x86_64.rpm"
+  - "python-psycopg2"
+  - "python36-psycopg2"
 
 pg_datadir: "/var/lib/pgsql/{{ pg_version }}/data/"
 pg_backupdir: "/var/lib/pgsql/{{ pg_version }}/backups"

--- a/ansible/tasks/build/centos/register-host.yml
+++ b/ansible/tasks/build/centos/register-host.yml
@@ -7,6 +7,7 @@
             ansible_ssh_pass="{{ image_pass }}"
             ansible_connection="ssh"
             ansible_host_key_checking=false
+            ansible_python_interpreter="/usr/bin/python3"
   delegate_to: builder
 - name: Wait for build VM to be reachable via SSH
   wait_for: host="{{ zone_nics[0].ip }}"

--- a/ansible/templates/centos-7/ks.cfg.j2
+++ b/ansible/templates/centos-7/ks.cfg.j2
@@ -94,7 +94,6 @@ logging --level=debug
 -tuned
 -virt-what
 -wpa_supplicant
--python3
 
 -pygobject3-base
 -gobject-introspection
@@ -109,6 +108,7 @@ logging --level=debug
 -plymouth*
 -chrony
 
+python3
 bzip2
 yum-utils
 acpid

--- a/ansible/templates/centos-7/ks.cfg.j2
+++ b/ansible/templates/centos-7/ks.cfg.j2
@@ -94,6 +94,7 @@ logging --level=debug
 -tuned
 -virt-what
 -wpa_supplicant
+-python3
 
 -pygobject3-base
 -gobject-introspection

--- a/ansible/vars/build/vm/base-centos-7.yml
+++ b/ansible/vars/build/vm/base-centos-7.yml
@@ -8,9 +8,9 @@ builder_download_url: "{{ builder.appliance.url }}/base-centos-7/_build"
 centos_mirror: "{{ builder_centos_mirror }}/7/os/x86_64/images/pxeboot"
 centos_files:
   - file: vmlinuz
-    sha256sum: 225fd77bec0f02dd6abba7ad39332ffededb7778d8b01ba3bb921027b468eef8
+    sha256sum: 156ddeaccea0ee51eb9af42b2551f393f84d6adaf7d257fa5b174657d38cead6
   - file: initrd.img
-    sha256sum: 38ac551a17a33410c456d8bde4c9c25464e061239906b2d316882474daeec0ea
+    sha256sum: 8c97a6f32ae8ab59425bdff8321eb8d99827313fb51e5498e2fcb438befa3d83
 zone_brand: kvm
 zone_vnc_port: "{{ build_vnc_ports.base_centos7 | default(build_vnc_port) | mandatory }}"
 zone_uuid: 316ae519-a88e-49e1-8eb3-d55d36aecbbf


### PR DESCRIPTION
and migrate VM installs to python3 to fix problems caused by python2 incompatibilities

Related to erigones/esdc-ce#459