### PR TITLE
Replace sha256sum and  add recent gitlab ce version with centos-8

### DIFF
--- a/ansible/build-contrib-gitlab-ce.yml
+++ b/ansible/build-contrib-gitlab-ce.yml
@@ -16,6 +16,7 @@
   tasks:
     - include: tasks/build/centos/register-host.yml
         hostname=contrib-gitlab-ce
+        ansible_python_interpreter="{{ python_path | default('/usr/bin/python3') }}"
 
 - name: Install and configure appliance
   hosts: contrib-gitlab-ce

--- a/ansible/roles/contrib-gitlab-ce/tasks/main.yml
+++ b/ansible/roles/contrib-gitlab-ce/tasks/main.yml
@@ -1,5 +1,5 @@
 - fail: msg="Invalid OS; Only CentOS 7 is supported."
-  when: ansible_distribution != "CentOS" or ansible_distribution_major_version != "7"
+  when: ansible_distribution != "CentOS" or ansible_distribution_major_version != "8"
 
 - name: Install required packages
   yum: name="{{ item }}" state=present
@@ -19,7 +19,7 @@
 # Using the yum module directly with the RPM URL does not work
 # Downloading to /tmp (tmpfs on RHEL 7) => we don't have to delete it
 - name: Download GitLab CE {{ gitlab_ce_version }} RPM package
-  get_url: url="https://packages.gitlab.com/gitlab/gitlab-ce/packages/el/7/gitlab-ce-{{ gitlab_ce_version }}-ce.0.el7.x86_64.rpm/download"
+  get_url: url="https://packages.gitlab.com/gitlab/gitlab-ce/packages/el/8/gitlab-ce-{{ gitlab_ce_version }}-ce.0.el8.x86_64.rpm/download"
            dest="/tmp/gitlab-ce.rpm"
            checksum="sha1:{{ gitlab_ce_checksum }}"
 

--- a/ansible/roles/contrib-gitlab-ce/tasks/main.yml
+++ b/ansible/roles/contrib-gitlab-ce/tasks/main.yml
@@ -1,4 +1,4 @@
-- fail: msg="Invalid OS; Only CentOS 7 is supported."
+- fail: msg="Invalid OS; Only CentOS 8 is supported."
   when: ansible_distribution != "CentOS" or ansible_distribution_major_version != "8"
 
 - name: Install required packages

--- a/ansible/tasks/build/centos/kickstart.yml
+++ b/ansible/tasks/build/centos/kickstart.yml
@@ -17,7 +17,7 @@
 - name: Download kernel and initrd
   get_url: url="{{ centos_mirror }}/{{ item.file }}"
            dest="/zones/{{ zone_uuid }}/root/{{ item.file }}"
-           sha256sum="{{ item.sha256sum }}"
+           checksum="sha256:{{ item.sha256sum }}"
   with_items: "{{ centos_files }}"
 
 - name: Ensure VM is running

--- a/ansible/tasks/build/centos/register-host.yml
+++ b/ansible/tasks/build/centos/register-host.yml
@@ -7,7 +7,7 @@
             ansible_ssh_pass="{{ image_pass }}"
             ansible_connection="ssh"
             ansible_host_key_checking=false
-            ansible_python_interpreter="{{ python_path | default('/usr/bin/python') }}"
+            ansible_python_interpreter="{{ python_path | default('/usr/bin/python3') }}"
   delegate_to: builder
 - name: Wait for build VM to be reachable via SSH
   wait_for: host="{{ zone_nics[0].ip }}"

--- a/ansible/tasks/build/centos/register-host.yml
+++ b/ansible/tasks/build/centos/register-host.yml
@@ -7,7 +7,7 @@
             ansible_ssh_pass="{{ image_pass }}"
             ansible_connection="ssh"
             ansible_host_key_checking=false
-            ansible_python_interpreter="{{ python_path | default('/usr/bin/python3') }}"
+            ansible_python_interpreter="{{ python_path | default('/usr/bin/python') }}"
   delegate_to: builder
 - name: Wait for build VM to be reachable via SSH
   wait_for: host="{{ zone_nics[0].ip }}"

--- a/ansible/vars/build/os/contrib-gitlab-ce.yml
+++ b/ansible/vars/build/os/contrib-gitlab-ce.yml
@@ -14,5 +14,5 @@ firewall_allowed_tcp_ports:
 selinux_permissive_domains:
   - zabbix_agent_t
 
-gitlab_ce_version: "9.5.6"
-gitlab_ce_checksum: "815733529d0ec5da6c47928c46503ed20fd860d7"  # sha1
+gitlab_ce_version: "13.6.1"
+gitlab_ce_checksum: "6bf4441113db9f67916375f94477fe3b34815a8a"  # sha1

--- a/ansible/vars/build/vm/contrib-gitlab-ce.yml
+++ b/ansible/vars/build/vm/contrib-gitlab-ce.yml
@@ -1,6 +1,6 @@
 # Dependencies: base.yml, zone.yml
 image_name: gitlab-ce
-image_desc: "GitLab Community Edition (Omnibus) {{ gitlab_ce_version }} on CentOS 7"
+image_desc: "GitLab Community Edition (Omnibus) {{ gitlab_ce_version }} on CentOS 8"
 image_homepage: "{{ image_contrib_homepage }}/gitlab-ce.rst"
 image_requirements:
   min_ram: 1024


### PR DESCRIPTION
thats all whats needed, i think.

for gitlab-ce role working with centos-8 some variables needs to be added at `ansible/vars/build/vm/contrib-gitlab-ce.yml` i think?

```
builder_base_centos_imgmanifest: base-centos-8-kvm-latest.imgmanifest
builder_base_centos_imgfile: base-centos-8-kvm-latest.zfs.gz
builder_base_centos_imgmanifest_url: "{{ builder.appliance.url }}/base-centos-8-kvm/{{ builder_base_centos_imgmanifest }}"
builder_base_centos_imgfile_url: "{{ builder.appliance.url }}/base-centos-8-kvm/{{ builder_base_centos_imgfile }}"
```
assuming these are needed?